### PR TITLE
add status flag to matches. drop useless columns from schema.

### DIFF
--- a/t-king-server/db/queries/players/getPlayers.sql
+++ b/t-king-server/db/queries/players/getPlayers.sql
@@ -1,3 +1,3 @@
 SELECT id, user_id, name FROM players
 WHERE tournament_id = $1
-ORDER BY position ASC;
+ORDER BY id;

--- a/t-king-server/lib/tournament.js
+++ b/t-king-server/lib/tournament.js
@@ -1,3 +1,15 @@
+const getMatchStatus = (match) => {
+  if (match.winner) {
+    return 'complete'
+  } else if (match.player1_score !== null) {
+    return 'active'
+  } else if (match.player1 && match.player2) {
+    return 'ready'
+  } else {
+    return 'waiting'
+  }
+}
+
 /**
 * Creates a new Player
 * @class
@@ -133,11 +145,7 @@ class Bracket {
         match.player1_score = existingMatch.player1_score
         match.player2_score = existingMatch.player2_score
         match.winner = existingMatch.winner
-        match.active = existingMatch.active
-        match.ready = false
-        if (!match.active && !match.winner && match.player1 && match.player2) {
-          match.ready = true;
-        }
+        match.status = getMatchStatus(match)
         if (match.winner) {
           var winner = players.find(p => p.id === match.winner)
           match.setWinner(winner)

--- a/t-king-server/schema.sql
+++ b/t-king-server/schema.sql
@@ -15,13 +15,9 @@ CREATE TABLE "tournaments" (
 CREATE TABLE "matches" (
 	"id" serial NOT NULL,
 	"tournament_id" integer NOT NULL,
-	"player1" integer,
-	"player2" integer,
 	"player1_score" integer,
 	"player2_score" integer,
 	"winner" integer,
-	"active" BOOLEAN NOT NULL DEFAULT 'false',
-	"ready" BOOLEAN NOT NULL DEFAULT 'false',
 	CONSTRAINT matches_pk PRIMARY KEY ("id")
 ) WITH (
   OIDS=FALSE
@@ -32,7 +28,6 @@ CREATE TABLE "matches" (
 CREATE TABLE "players" (
 	"id" serial NOT NULL,
 	"tournament_id" integer NOT NULL,
-	"position" integer NOT NULL,
 	"user_id" integer,
 	"name" TEXT,
 	CONSTRAINT players_pk PRIMARY KEY ("id")
@@ -72,8 +67,6 @@ CREATE TABLE "comments" (
 ALTER TABLE "tournaments" ADD CONSTRAINT "tournaments_fk0" FOREIGN KEY ("creator") REFERENCES "users"("id");
 
 ALTER TABLE "matches" ADD CONSTRAINT "matches_fk0" FOREIGN KEY ("tournament_id") REFERENCES "tournaments"("id");
-ALTER TABLE "matches" ADD CONSTRAINT "matches_fk1" FOREIGN KEY ("player1") REFERENCES "players"("id");
-ALTER TABLE "matches" ADD CONSTRAINT "matches_fk2" FOREIGN KEY ("player2") REFERENCES "players"("id");
 ALTER TABLE "matches" ADD CONSTRAINT "matches_fk3" FOREIGN KEY ("winner") REFERENCES "players"("id");
 
 ALTER TABLE "players" ADD CONSTRAINT "players_fk0" FOREIGN KEY ("tournament_id") REFERENCES "tournaments"("id");

--- a/t-king-server/server/controllers/tournament-controller.js
+++ b/t-king-server/server/controllers/tournament-controller.js
@@ -14,14 +14,12 @@ const createTournament = (req, res) => {
     type,
     creator: req.user.id
   }).then(tournament => {
-    var count = 0;
     db.players.insert(players.map(player => {
       player.tournament_id = tournament.id;
-      player.position = ++count;
       return player;
     })).then(() => {
       var matches = []
-      while (--count) {
+      while (matches.length < players.length-1) {
         matches.push({tournament_id:tournament.id})
       }
       db.matches.insert(matches)


### PR DESCRIPTION
The status of a match can be determined by looking at the relevant columns in the database. All matches will have a default status of 'waiting'.  If a match has a winner, we set the status to 'complete'. If player1_score is set, the match will be considered to be 'active'. If both player1 and player2 are set, the match will be considered 'ready'. By using this process, we can drop useless columns from the database.

I have removed player1 and player2 columns from the matches table (we are no longer using these columns), as well as the position column from the players table. The player's position will be determined from the primary key instead.